### PR TITLE
Fix Lambda Function URL 403 Forbidden

### DIFF
--- a/infra/api.ts
+++ b/infra/api.ts
@@ -4,6 +4,7 @@ const tables = [roundsTable, wordsTable, playersTable, boardsTable];
 
 export const roundsApi = new sst.aws.Function("RoundsApi", {
   url: {
+    authorization: "none",
     cors: {
       allowOrigins: ["*"],
       allowMethods: ["GET", "POST", "PUT", "DELETE"],
@@ -16,6 +17,7 @@ export const roundsApi = new sst.aws.Function("RoundsApi", {
 
 export const wordsApi = new sst.aws.Function("WordsApi", {
   url: {
+    authorization: "none",
     cors: {
       allowOrigins: ["*"],
       allowMethods: ["GET", "POST", "PUT", "DELETE"],
@@ -28,6 +30,7 @@ export const wordsApi = new sst.aws.Function("WordsApi", {
 
 export const playersApi = new sst.aws.Function("PlayersApi", {
   url: {
+    authorization: "none",
     cors: {
       allowOrigins: ["*"],
       allowMethods: ["GET", "POST", "PUT", "DELETE"],
@@ -40,6 +43,7 @@ export const playersApi = new sst.aws.Function("PlayersApi", {
 
 export const boardsApi = new sst.aws.Function("BoardsApi", {
   url: {
+    authorization: "none",
     cors: {
       allowOrigins: ["*"],
       allowMethods: ["GET", "POST", "PUT", "DELETE"],


### PR DESCRIPTION
## Summary
- Disable IAM authorization on all 4 Lambda Function URLs (`roundsApi`, `wordsApi`, `playersApi`, `boardsApi`)
- Lambda Function URLs default to `authorization: "iam"` which requires AWS Signature V4 signed requests
- Frontend sends plain HTTP requests without signing, causing 403 Forbidden

## Test plan
- [ ] `sst deploy` (or `sst dev`) completes successfully
- [ ] `curl -X POST <roundsApi-url> -H 'Content-Type: application/json' -d '{"name":"test","boardSize":3}'` returns 200
- [ ] Frontend on localhost:3000 can create rounds without 403