### PR TITLE
Fix board not found error for player board preview

### DIFF
--- a/packages/web/app/round/[code]/board/[player]/page.tsx
+++ b/packages/web/app/round/[code]/board/[player]/page.tsx
@@ -32,7 +32,7 @@ export default function PlayerBoardPage() {
   const { data: board, error } = usePolling<BoardWithBingo>(fetchBoard, 4000, !!roundId);
 
   const boardNotFound =
-    error instanceof ApiRequestError && error.code === "NOT_FOUND";
+    !board && error instanceof ApiRequestError && error.code === "NOT_FOUND";
 
   if (boardNotFound) {
     return (


### PR DESCRIPTION
## Summary
- Handle the case where a player's board hasn't been created yet on the board preview page
- Show a user-friendly message ("Gracz nie otworzył jeszcze swojej planszy") instead of spinning indefinitely on "Loading board..."
- The board is created lazily when a player first visits their own board page, so previewing it before that would cause a 404 error from the API

Closes #49

## Test plan
- [ ] Navigate to a player's board before they have visited their board page — should show the friendly message
- [ ] Navigate to a player's board after they have created it — should show the board normally
- [ ] Verify the "Wróć" button navigates back correctly