### PR TITLE
Fix word selection for boards and sort ties alphabetically

### DIFF
--- a/packages/core/src/word.ts
+++ b/packages/core/src/word.ts
@@ -92,6 +92,6 @@ export namespace Word {
 
   export async function listByVotes(roundId: string): Promise<Info[]> {
     const words = await listByRound(roundId);
-    return words.sort((a, b) => b.votes - a.votes);
+    return words.sort((a, b) => b.votes - a.votes || a.text.localeCompare(b.text));
   }
 }

--- a/packages/functions/src/boards.ts
+++ b/packages/functions/src/boards.ts
@@ -53,7 +53,8 @@ export const handler = wrapHandler(async (event) => {
       }
 
       const words = await Word.listByVotes(roundId);
-      const wordTexts = words.map((w) => w.text);
+      const totalCells = round.boardSize * round.boardSize;
+      const wordTexts = words.slice(0, totalCells).map((w) => w.text);
       const board = await Board.create({
         roundId,
         playerName,


### PR DESCRIPTION
## Summary
- **Same words for all players**: Board creation now selects the top-voted words deterministically (slices to exactly `boardSize * boardSize` before passing to `Board.create()`), ensuring all players get the same set of words with different arrangements.
- **Deterministic sort for equal votes**: `Word.listByVotes()` now applies a secondary alphabetical sort (`localeCompare`) when words have equal vote counts, eliminating random ordering.

## Test plan
- [ ] Create a round with more words than board cells (e.g., 20 words for a 4x4 board)
- [ ] Have multiple players create boards and verify all boards contain the same 16 words
- [ ] Verify words with 0 votes appear in alphabetical order in the word list
- [ ] Verify boards still have different cell arrangements (shuffle still works)

Closes #50