### PR TITLE
feat: add undo mark (toggle cell) on bingo board

### DIFF
--- a/packages/functions/src/boards.ts
+++ b/packages/functions/src/boards.ts
@@ -31,6 +31,26 @@ export const handler = wrapHandler(async (event) => {
         return json(200, { ...board, hasBingo: bingo.hasBingo, bingoLines: bingo.lines });
       }
 
+      if (body.action === "unmark") {
+        const roundId = body.roundId as string;
+        const playerName = body.playerName as string;
+        const cellIndex = body.cellIndex as number;
+        const pin = body.pin as string;
+        if (!roundId || !playerName || cellIndex === undefined || !pin) {
+          return json(400, {
+            error: "roundId, playerName, cellIndex, and pin are required",
+            code: "VALIDATION_ERROR",
+          });
+        }
+        const pinValid = await Player.verifyPin(roundId, playerName, pin);
+        if (!pinValid) {
+          return json(401, { error: "Invalid PIN", code: "INVALID_PIN" });
+        }
+        const board = await Board.unmarkCell(roundId, playerName, cellIndex);
+        const bingo = Board.checkBingo(board.marked, board.size);
+        return json(200, { ...board, hasBingo: bingo.hasBingo, bingoLines: bingo.lines });
+      }
+
       // Create board from top-voted words
       const roundId = body.roundId as string;
       const playerName = body.playerName as string;

--- a/packages/web/lib/api.ts
+++ b/packages/web/lib/api.ts
@@ -155,6 +155,12 @@ export const boards = {
       method: "POST",
       body: JSON.stringify({ action: "mark", roundId, playerName, cellIndex, pin }),
     }),
+
+  unmark: (roundId: string, playerName: string, cellIndex: number, pin: string) =>
+    request<import("./types").BoardWithBingo>(`${BOARDS_API}`, {
+      method: "POST",
+      body: JSON.stringify({ action: "unmark", roundId, playerName, cellIndex, pin }),
+    }),
 };
 
 export { ApiRequestError };


### PR DESCRIPTION
## Summary
- Add `Board.unmarkCell()` method in core package to set a cell's marked state to false
- Add "unmark" action handler in the boards Lambda function with PIN verification
- Add `boards.unmark()` API client method in the web package
- Update `handleToggleCell` to support toggling: tap marked cell to unmark, tap unmarked cell to mark
- Handle bingo loss on unmark: dismiss celebration modal and reset bingo state

Closes #51

## Test plan
- [ ] Mark a cell on the bingo board, verify it becomes marked
- [ ] Tap a marked cell again, verify it becomes unmarked
- [ ] Complete a bingo line, verify celebration modal appears
- [ ] Unmark a cell in the bingo line, verify modal is dismissed
- [ ] Verify optimistic UI update reverts on API error