### PR TITLE
feat: add unvote (toggle vote) functionality

### DIFF
--- a/packages/functions/src/words.ts
+++ b/packages/functions/src/words.ts
@@ -27,6 +27,24 @@ export const handler = wrapHandler(async (event) => {
         await Word.vote(roundId, wordId, playerName);
         return json(200, { ok: true });
       }
+      if (body.action === "unvote") {
+        const roundId = body.roundId as string;
+        const wordId = body.wordId as string;
+        const playerName = body.playerName as string;
+        const pin = body.pin as string;
+        if (!roundId || !wordId || !playerName || !pin) {
+          return json(400, {
+            error: "roundId, wordId, playerName, and pin are required",
+            code: "VALIDATION_ERROR",
+          });
+        }
+        const pinValid = await Player.verifyPin(roundId, playerName, pin);
+        if (!pinValid) {
+          return json(401, { error: "Invalid PIN", code: "INVALID_PIN" });
+        }
+        await Word.unvote(roundId, wordId, playerName);
+        return json(200, { ok: true });
+      }
       const roundId = body.roundId as string;
       const submittedBy = body.submittedBy as string;
       const pin = body.pin as string;

--- a/packages/web/app/round/[code]/page.tsx
+++ b/packages/web/app/round/[code]/page.tsx
@@ -103,6 +103,18 @@ export default function RoundPage() {
     }
   };
 
+  const handleUnvote = async (wordId: string) => {
+    if (!round || !pin) return;
+    try {
+      await wordsApi.unvote(round.roundId, wordId, playerName, pin);
+      refreshWords();
+    } catch (err) {
+      if (err instanceof Error) {
+        addToast(err.message, "error");
+      }
+    }
+  };
+
   const handleStartGame = async () => {
     if (!round || !pin) return;
     try {
@@ -170,6 +182,7 @@ export default function RoundPage() {
           <WordList
             words={currentWords}
             onVote={handleVote}
+            onUnvote={handleUnvote}
             currentPlayer={playerName}
             disabled={round.status !== "collecting"}
           />

--- a/packages/web/components/WordList.stories.tsx
+++ b/packages/web/components/WordList.stories.tsx
@@ -65,6 +65,9 @@ export const Default: Story = {
     onVote: async (wordId: string) => {
       console.log("Voted for:", wordId);
     },
+    onUnvote: async (wordId: string) => {
+      console.log("Unvoted for:", wordId);
+    },
     currentPlayer: "Alice",
     disabled: false,
   },
@@ -74,6 +77,7 @@ export const Empty: Story = {
   args: {
     words: [],
     onVote: async () => {},
+    onUnvote: async () => {},
     currentPlayer: "Alice",
     disabled: false,
   },
@@ -83,6 +87,7 @@ export const Disabled: Story = {
   args: {
     words: sampleWords,
     onVote: async () => {},
+    onUnvote: async () => {},
     currentPlayer: "Alice",
     disabled: true,
   },

--- a/packages/web/components/WordList.tsx
+++ b/packages/web/components/WordList.tsx
@@ -5,6 +5,7 @@ import type { Word } from "@/lib/types";
 interface WordListProps {
   words: Word[];
   onVote: (wordId: string) => Promise<void>;
+  onUnvote?: (wordId: string) => Promise<void>;
   currentPlayer: string;
   disabled?: boolean;
 }
@@ -12,6 +13,7 @@ interface WordListProps {
 export default function WordList({
   words,
   onVote,
+  onUnvote,
   currentPlayer,
   disabled = false,
 }: WordListProps) {
@@ -33,13 +35,15 @@ export default function WordList({
             <span className="text-xs text-gray-400">by {word.submittedBy}</span>
             <button
               type="button"
-              onClick={() => onVote(word.wordId)}
-              disabled={hasVoted || disabled}
+              onClick={() =>
+                hasVoted ? onUnvote?.(word.wordId) : onVote(word.wordId)
+              }
+              disabled={!hasVoted && disabled}
               className={`flex items-center gap-1 rounded-full px-2.5 py-1 text-xs font-medium transition-colors ${
                 hasVoted
-                  ? "bg-corpo-100 text-corpo-900"
+                  ? "bg-corpo-100 text-corpo-900 hover:bg-red-50 hover:text-red-700"
                   : "bg-gray-100 text-gray-600 hover:bg-corpo-50 hover:text-corpo-900"
-              } disabled:cursor-not-allowed`}
+              } disabled:cursor-not-allowed disabled:opacity-50`}
             >
               <span>{hasVoted ? "\u2605" : "\u2606"}</span>
               <span>{word.votes}</span>

--- a/packages/web/lib/api.ts
+++ b/packages/web/lib/api.ts
@@ -117,6 +117,12 @@ export const words = {
       body: JSON.stringify({ action: "vote", roundId, wordId, playerName, pin }),
     }),
 
+  unvote: (roundId: string, wordId: string, playerName: string, pin: string) =>
+    request<{ ok: boolean }>(`${WORDS_API}`, {
+      method: "POST",
+      body: JSON.stringify({ action: "unvote", roundId, wordId, playerName, pin }),
+    }),
+
   list: (roundId: string, sortBy?: "votes") =>
     request<import("./types").Word[]>(`${WORDS_API}${qs({ roundId, sortBy })}`),
 };


### PR DESCRIPTION
## Summary
- Added `Word.unvote()` method in core layer with read-modify-write approach for DynamoDB
- Added `unvote` action handler in Lambda function with PIN verification
- Added `words.unvote()` API client method in frontend
- Made the WordList vote button a toggle: clicking a voted word removes the vote, clicking an unvoted word adds a vote
- Updated button styles with red hover hint when unvoting
- Updated Storybook stories with `onUnvote` handlers

## Test plan
- [ ] Vote on a word, verify the filled star appears
- [ ] Click the voted word again, verify the vote is removed (star becomes outline, count decrements)
- [ ] Verify the unvote button shows red hover styling
- [ ] Verify unvoting is disabled when the round is not in "collecting" status for unvoted words, but still works for already-voted words
- [ ] Verify PIN validation works for unvote requests

Closes #53