### PR TITLE
feat: add leave round with board regeneration

### DIFF
--- a/packages/core/src/board.ts
+++ b/packages/core/src/board.ts
@@ -1,4 +1,4 @@
-import { GetCommand, PutCommand, QueryCommand, UpdateCommand } from "@aws-sdk/lib-dynamodb";
+import { DeleteCommand, GetCommand, PutCommand, QueryCommand, UpdateCommand } from "@aws-sdk/lib-dynamodb";
 import { Resource } from "sst";
 import { client } from "./dynamo.js";
 import { ValidationError } from "./round.js";
@@ -151,6 +151,15 @@ export namespace Board {
       }),
     );
     return (result.Items ?? []) as Info[];
+  }
+
+  export async function remove(roundId: string, playerName: string): Promise<void> {
+    await client.send(
+      new DeleteCommand({
+        TableName: Resource.Boards.name,
+        Key: { roundId, playerName },
+      }),
+    );
   }
 
   export async function markCell(

--- a/packages/functions/src/boards.ts
+++ b/packages/functions/src/boards.ts
@@ -31,6 +31,24 @@ export const handler = wrapHandler(async (event) => {
         return json(200, { ...board, hasBingo: bingo.hasBingo, bingoLines: bingo.lines });
       }
 
+      if (body.action === "leave") {
+        const roundId = body.roundId as string;
+        const playerName = body.playerName as string;
+        const pin = body.pin as string;
+        if (!roundId || !playerName || !pin) {
+          return json(400, {
+            error: "roundId, playerName, and pin are required",
+            code: "VALIDATION_ERROR",
+          });
+        }
+        const pinValid = await Player.verifyPin(roundId, playerName, pin);
+        if (!pinValid) {
+          return json(401, { error: "Invalid PIN", code: "INVALID_PIN" });
+        }
+        await Board.remove(roundId, playerName);
+        return json(200, { ok: true });
+      }
+
       // Create board from top-voted words
       const roundId = body.roundId as string;
       const playerName = body.playerName as string;

--- a/packages/web/app/round/[code]/board/page.tsx
+++ b/packages/web/app/round/[code]/board/page.tsx
@@ -7,10 +7,12 @@ import BingoModal from "@/components/BingoModal";
 import Header from "@/components/Header";
 import PlayerList from "@/components/PlayerList";
 import ToastContainer from "@/components/ToastContainer";
+import Button from "@/components/ui/Button";
+import Modal from "@/components/ui/Modal";
 import { boards, players as playersApi, rounds } from "@/lib/api";
 import { useHaptic, usePolling } from "@/lib/hooks";
 import { useNotifications } from "@/lib/notifications";
-import { getPinForSession, getSession } from "@/lib/session";
+import { clearSession, getPinForSession, getSession } from "@/lib/session";
 import type { BoardWithBingo, Player, Round } from "@/lib/types";
 
 interface PlayerProgress {
@@ -36,6 +38,7 @@ export default function BoardPage() {
   const [showBingoModal, setShowBingoModal] = useState(false);
   const [bingoCount, setBingoCount] = useState(0);
   const [playerProgress, setPlayerProgress] = useState<PlayerProgress[]>([]);
+  const [showLeaveDialog, setShowLeaveDialog] = useState(false);
   const prevBingo = useRef(false);
   const { toasts, dismissToast, notifyPlayerChanges } = useNotifications(playerName);
 
@@ -153,6 +156,17 @@ export default function BoardPage() {
     }
   };
 
+  const handleLeaveRound = async () => {
+    if (!round || !pin) return;
+    try {
+      await boards.leave(round.roundId, playerName, pin);
+      clearSession(code);
+      router.push("/");
+    } catch {
+      // silently ignore — user stays on page
+    }
+  };
+
   if (loading || !board) {
     return (
       <main className="flex min-h-screen items-center justify-center">
@@ -178,6 +192,11 @@ export default function BoardPage() {
               bingoLines={board.bingoLines}
               onToggleCell={handleToggleCell}
             />
+            <div className="mt-4 flex justify-center">
+              <Button variant="ghost" size="sm" onClick={() => setShowLeaveDialog(true)}>
+                Opuść rundę
+              </Button>
+            </div>
           </div>
 
           <div className="w-full md:min-w-[240px] md:max-w-xs">
@@ -210,6 +229,21 @@ export default function BoardPage() {
       {showBingoModal && (
         <BingoModal bingoCount={bingoCount} onClose={() => setShowBingoModal(false)} />
       )}
+      <Modal open={showLeaveDialog} onClose={() => setShowLeaveDialog(false)}>
+        <h2 className="text-lg font-semibold text-gray-900">Opuść rundę?</h2>
+        <p className="mt-2 text-sm text-gray-600">
+          Twoja plansza zostanie usunięta. Po ponownym dołączeniu otrzymasz nową planszę z losowym
+          układem słów.
+        </p>
+        <div className="mt-4 flex gap-3 justify-end">
+          <Button variant="ghost" size="sm" onClick={() => setShowLeaveDialog(false)}>
+            Anuluj
+          </Button>
+          <Button variant="danger" size="sm" onClick={handleLeaveRound}>
+            Opuść rundę
+          </Button>
+        </div>
+      </Modal>
       <ToastContainer toasts={toasts} onDismiss={dismissToast} />
     </div>
   );

--- a/packages/web/lib/api.ts
+++ b/packages/web/lib/api.ts
@@ -155,6 +155,12 @@ export const boards = {
       method: "POST",
       body: JSON.stringify({ action: "mark", roundId, playerName, cellIndex, pin }),
     }),
+
+  leave: (roundId: string, playerName: string, pin: string) =>
+    request<{ ok: boolean }>(`${BOARDS_API}`, {
+      method: "POST",
+      body: JSON.stringify({ action: "leave", roundId, playerName, pin }),
+    }),
 };
 
 export { ApiRequestError };


### PR DESCRIPTION
## Summary
- Add `Board.remove()` method to delete a player's board from DynamoDB
- Add `leave` action handler in boards Lambda with PIN verification
- Add `boards.leave()` API client method
- Add "Opuść rundę" button with confirmation dialog on the board page
- On leave: board is deleted, session cleared, player redirected to home
- On rejoin: existing board-not-found logic automatically creates a new board

Closes #54

## Test plan
- [ ] Click "Opuść rundę" button on board page — confirmation dialog appears
- [ ] Click "Anuluj" — dialog closes, nothing happens
- [ ] Click "Opuść rundę" in dialog — board deleted, redirected to home
- [ ] Rejoin the same round — new board is generated with different word arrangement
- [ ] Verify PIN validation works (invalid PIN should not allow leaving)