### PR TITLE
feat: add content-aware page titles

### DIFF
--- a/packages/web/app/create/page.tsx
+++ b/packages/web/app/create/page.tsx
@@ -4,8 +4,10 @@ import { useRouter } from "next/navigation";
 import { useState } from "react";
 import { Button, Input } from "@/components/ui";
 import { rounds } from "@/lib/api";
+import { usePageTitle } from "@/lib/hooks";
 
 export default function CreatePage() {
+  usePageTitle("New Round");
   const router = useRouter();
   const [name, setName] = useState("");
   const [boardSize, setBoardSize] = useState<3 | 4>(4);

--- a/packages/web/app/page.tsx
+++ b/packages/web/app/page.tsx
@@ -3,8 +3,10 @@
 import { useRouter } from "next/navigation";
 import { useState } from "react";
 import { Button } from "@/components/ui";
+import { usePageTitle } from "@/lib/hooks";
 
 export default function Home() {
+  usePageTitle();
   const router = useRouter();
   const [code, setCode] = useState("");
   const [error, setError] = useState("");

--- a/packages/web/app/round/[code]/board/[player]/page.tsx
+++ b/packages/web/app/round/[code]/board/[player]/page.tsx
@@ -5,7 +5,7 @@ import { useCallback, useEffect, useState } from "react";
 import BingoBoard from "@/components/BingoBoard";
 import Header from "@/components/Header";
 import { ApiRequestError, boards, rounds } from "@/lib/api";
-import { usePolling } from "@/lib/hooks";
+import { usePageTitle, usePolling } from "@/lib/hooks";
 import type { BoardWithBingo } from "@/lib/types";
 
 export default function PlayerBoardPage() {
@@ -13,6 +13,8 @@ export default function PlayerBoardPage() {
   const router = useRouter();
   const code = (params.code as string).toUpperCase();
   const playerName = decodeURIComponent(params.player as string);
+
+  usePageTitle(`${playerName}'s Board`);
 
   const [roundId, setRoundId] = useState<string | null>(null);
   const [roundName, setRoundName] = useState("");

--- a/packages/web/app/round/[code]/board/page.tsx
+++ b/packages/web/app/round/[code]/board/page.tsx
@@ -11,7 +11,7 @@ import Button from "@/components/ui/Button";
 import ShareCode from "@/components/ShareCode";
 import Modal from "@/components/ui/Modal";
 import { boards, players as playersApi, rounds } from "@/lib/api";
-import { useHaptic, usePolling } from "@/lib/hooks";
+import { useHaptic, usePageTitle, usePolling } from "@/lib/hooks";
 import { useNotifications } from "@/lib/notifications";
 import { clearSession, getPinForSession, getSession } from "@/lib/session";
 import type { BoardWithBingo, Player, Round } from "@/lib/types";
@@ -28,6 +28,8 @@ export default function BoardPage() {
   const router = useRouter();
   const code = (params.code as string).toUpperCase();
   const haptic = useHaptic();
+
+  usePageTitle("Board");
 
   const session = typeof window !== "undefined" ? getSession(code) : null;
   const playerName = session?.playerName ?? "";

--- a/packages/web/app/round/[code]/join/page.tsx
+++ b/packages/web/app/round/[code]/join/page.tsx
@@ -4,9 +4,11 @@ import { useParams, useRouter } from "next/navigation";
 import { useEffect, useState } from "react";
 import { Button, Input, PinInput } from "@/components/ui";
 import { ApiRequestError, players, rounds } from "@/lib/api";
+import { usePageTitle } from "@/lib/hooks";
 import { getSession, setPinForSession, setSession } from "@/lib/session";
 
 export default function JoinPage() {
+  usePageTitle("Join");
   const params = useParams();
   const router = useRouter();
   const code = (params.code as string).toUpperCase();

--- a/packages/web/app/round/[code]/page.tsx
+++ b/packages/web/app/round/[code]/page.tsx
@@ -8,7 +8,7 @@ import ToastContainer from "@/components/ToastContainer";
 import WordInput from "@/components/WordInput";
 import WordList from "@/components/WordList";
 import { players as playersApi, rounds, words as wordsApi } from "@/lib/api";
-import { usePolling } from "@/lib/hooks";
+import { usePageTitle, usePolling } from "@/lib/hooks";
 import { useNotifications } from "@/lib/notifications";
 import { getPinForSession, getSession } from "@/lib/session";
 import type { Player, Round, Word } from "@/lib/types";
@@ -27,6 +27,8 @@ export default function RoundPage() {
   const [error, setError] = useState("");
   const { toasts, addToast, dismissToast, notifyPlayerChanges, notifyStatusChange } =
     useNotifications(playerName);
+
+  usePageTitle(round?.name ?? "Round");
 
   // Fetch round data
   useEffect(() => {

--- a/packages/web/app/round/[code]/results/page.tsx
+++ b/packages/web/app/round/[code]/results/page.tsx
@@ -6,6 +6,7 @@ import BingoBoard from "@/components/BingoBoard";
 import Header from "@/components/Header";
 import { Badge, Button, Card, CardBody, CardHeader } from "@/components/ui";
 import { boards, players as playersApi, rounds } from "@/lib/api";
+import { usePageTitle } from "@/lib/hooks";
 import type { BoardWithBingo, Player, Round } from "@/lib/types";
 
 interface PlayerRanking {
@@ -55,6 +56,8 @@ function pickHeader(roundId: string): string {
 }
 
 export default function ResultsPage() {
+  usePageTitle("Results");
+
   const params = useParams();
   const router = useRouter();
   const code = (params.code as string).toUpperCase();

--- a/packages/web/lib/hooks.ts
+++ b/packages/web/lib/hooks.ts
@@ -2,6 +2,14 @@
 
 import { useCallback, useEffect, useRef, useState } from "react";
 
+const BASE_TITLE = "KorpoBingo";
+
+export function usePageTitle(title?: string | null) {
+  useEffect(() => {
+    document.title = title ? `${title} - ${BASE_TITLE}` : BASE_TITLE;
+  }, [title]);
+}
+
 export function usePolling<T>(
   fetcher: () => Promise<T>,
   intervalMs: number,


### PR DESCRIPTION
Closes #67

## Summary
- Added `usePageTitle(title)` hook in `packages/web/lib/hooks.ts` that sets `document.title` with a ` - KorpoBingo` suffix (or just `KorpoBingo` when empty)
- Integrated the hook into all 7 page components with appropriate titles:
  - `/` → `KorpoBingo`
  - `/create` → `New Round - KorpoBingo`
  - `/round/[code]` → `{round.name} - KorpoBingo` (fallback: `Round - KorpoBingo`)
  - `/round/[code]/join` → `Join - KorpoBingo`
  - `/round/[code]/board` → `Board - KorpoBingo`
  - `/round/[code]/board/[player]` → `{playerName}'s Board - KorpoBingo`
  - `/round/[code]/results` → `Results - KorpoBingo`

## Test plan
- [ ] Navigate to each route and verify the browser tab title updates correctly
- [ ] Verify the round page shows the round name once loaded, and "Round" as fallback while loading
- [ ] Verify the player board page shows the player's name in the title