### PR TITLE
fix: guard board access during collecting phase

### DIFF
--- a/packages/functions/src/boards.ts
+++ b/packages/functions/src/boards.ts
@@ -26,6 +26,13 @@ export const handler = wrapHandler(async (event) => {
         if (!pinValid) {
           return json(401, { error: "Invalid PIN", code: "INVALID_PIN" });
         }
+        const markRound = await Round.get(roundId);
+        if (!markRound || markRound.status === "collecting") {
+          return json(400, {
+            error: "Round is still in collecting phase",
+            code: "ROUND_NOT_PLAYING",
+          });
+        }
         const board = await Board.markCell(roundId, playerName, cellIndex);
         const bingo = Board.checkBingo(board.marked, board.size);
         return json(200, { ...board, hasBingo: bingo.hasBingo, bingoLines: bingo.lines });
@@ -45,6 +52,13 @@ export const handler = wrapHandler(async (event) => {
         const pinValid = await Player.verifyPin(roundId, playerName, pin);
         if (!pinValid) {
           return json(401, { error: "Invalid PIN", code: "INVALID_PIN" });
+        }
+        const unmarkRound = await Round.get(roundId);
+        if (!unmarkRound || unmarkRound.status === "collecting") {
+          return json(400, {
+            error: "Round is still in collecting phase",
+            code: "ROUND_NOT_PLAYING",
+          });
         }
         const board = await Board.unmarkCell(roundId, playerName, cellIndex);
         const bingo = Board.checkBingo(board.marked, board.size);
@@ -90,6 +104,12 @@ export const handler = wrapHandler(async (event) => {
       if (!round) {
         return json(404, { error: "Round not found", code: "NOT_FOUND" });
       }
+      if (round.status === "collecting") {
+        return json(400, {
+          error: "Round is still in collecting phase",
+          code: "ROUND_NOT_PLAYING",
+        });
+      }
 
       const words = await Word.listByVotes(roundId);
       const totalCells = round.boardSize * round.boardSize;
@@ -106,6 +126,13 @@ export const handler = wrapHandler(async (event) => {
     case "GET": {
       const roundId = requireParam(event, "roundId");
       const playerName = requireParam(event, "playerName");
+      const getRound = await Round.get(roundId);
+      if (getRound && getRound.status === "collecting") {
+        return json(409, {
+          error: "Round is still in collecting phase",
+          code: "ROUND_NOT_PLAYING",
+        });
+      }
       const board = await Board.get(roundId, playerName);
       if (!board) return json(404, { error: "Board not found", code: "NOT_FOUND" });
       const bingo = Board.checkBingo(board.marked, board.size);

--- a/packages/web/app/round/[code]/board/[player]/page.tsx
+++ b/packages/web/app/round/[code]/board/[player]/page.tsx
@@ -19,10 +19,14 @@ export default function PlayerBoardPage() {
 
   useEffect(() => {
     rounds.getByShareCode(code).then((r) => {
+      if (r.status === "collecting") {
+        router.push(`/round/${code}`);
+        return;
+      }
       setRoundId(r.roundId);
       setRoundName(r.name);
     });
-  }, [code]);
+  }, [code, router]);
 
   const fetchBoard = useCallback(
     () => (roundId ? boards.get(roundId, playerName) : Promise.reject()),
@@ -30,6 +34,14 @@ export default function PlayerBoardPage() {
   );
 
   const { data: board, error } = usePolling<BoardWithBingo>(fetchBoard, 4000, !!roundId);
+
+  const roundNotPlaying = error instanceof ApiRequestError && error.code === "ROUND_NOT_PLAYING";
+
+  useEffect(() => {
+    if (roundNotPlaying) {
+      router.push(`/round/${code}`);
+    }
+  }, [roundNotPlaying, code, router]);
 
   const boardNotFound = !board && error instanceof ApiRequestError && error.code === "NOT_FOUND";
 

--- a/packages/web/app/round/[code]/board/page.tsx
+++ b/packages/web/app/round/[code]/board/page.tsx
@@ -60,6 +60,11 @@ export default function BoardPage() {
         const r = await rounds.getByShareCode(code);
         setRound(r);
 
+        if (r.status === "collecting") {
+          router.push(`/round/${code}`);
+          return;
+        }
+
         if (r.status === "finished") {
           router.push(`/round/${code}/results`);
           return;


### PR DESCRIPTION
## Summary

- Backend: Added round status checks to all board endpoints (GET, POST create, POST mark/unmark) that return `400`/`409` with `ROUND_NOT_PLAYING` error code when round is still in collecting phase
- Frontend: Board page and player board view redirect to round lobby when status is `collecting`
- Handles race conditions at game start by catching `ROUND_NOT_PLAYING` errors and redirecting gracefully

## Changed files

- `packages/functions/src/boards.ts` — added collecting phase guards to GET and POST handlers
- `packages/web/app/round/[code]/board/page.tsx` — redirect to lobby if collecting
- `packages/web/app/round/[code]/board/[player]/page.tsx` — redirect to lobby if collecting, handle polling error

## Test plan

- [ ] Navigate to board page while round is in collecting phase — should redirect to round lobby
- [ ] Try to create a board via API while round is collecting — should get 400 ROUND_NOT_PLAYING
- [ ] Try GET board while round is collecting — should get 409 ROUND_NOT_PLAYING
- [ ] Try mark/unmark cell while round is collecting — should get 400 ROUND_NOT_PLAYING
- [ ] Normal board flow works when round is in playing phase
- [ ] View another player's board while collecting — redirects to lobby

Closes #63