### PR TITLE
feat: add structured logging and CloudWatch observability

### DIFF
--- a/infra/api.ts
+++ b/infra/api.ts
@@ -2,6 +2,14 @@ import { boardsTable, playersTable, roundsTable, wordsTable } from "./storage";
 
 const tables = [roundsTable, wordsTable, playersTable, boardsTable];
 
+const functionTransform: sst.aws.ApiGatewayV2RouteArgs["transform"] = {
+  function: {
+    logging: {
+      retention: "30 days",
+    },
+  },
+};
+
 export const api = new sst.aws.ApiGatewayV2("Api", {
   cors: {
     allowOrigins: ["*"],
@@ -13,19 +21,23 @@ export const api = new sst.aws.ApiGatewayV2("Api", {
 api.route("ANY /rounds", {
   handler: "packages/functions/src/rounds.handler",
   link: tables,
+  transform: functionTransform,
 });
 
 api.route("ANY /words", {
   handler: "packages/functions/src/words.handler",
   link: tables,
+  transform: functionTransform,
 });
 
 api.route("ANY /players", {
   handler: "packages/functions/src/players.handler",
   link: tables,
+  transform: functionTransform,
 });
 
 api.route("ANY /boards", {
   handler: "packages/functions/src/boards.handler",
   link: tables,
+  transform: functionTransform,
 });

--- a/infra/monitoring.ts
+++ b/infra/monitoring.ts
@@ -1,0 +1,80 @@
+import * as aws from "@pulumi/aws";
+
+const dashboardBody = {
+  widgets: [
+    {
+      type: "metric",
+      x: 0,
+      y: 0,
+      width: 12,
+      height: 6,
+      properties: {
+        title: "Request Volume",
+        metrics: [["KorpoBingo", "RequestCount", { stat: "Sum", period: 300 }]],
+        view: "timeSeries",
+        region: "us-east-1",
+        period: 300,
+      },
+    },
+    {
+      type: "metric",
+      x: 12,
+      y: 0,
+      width: 12,
+      height: 6,
+      properties: {
+        title: "Error Rate",
+        metrics: [["KorpoBingo", "ErrorCount", { stat: "Sum", period: 300 }]],
+        view: "timeSeries",
+        region: "us-east-1",
+        period: 300,
+      },
+    },
+    {
+      type: "metric",
+      x: 0,
+      y: 6,
+      width: 12,
+      height: 6,
+      properties: {
+        title: "Latency (p50 / p90 / p99)",
+        metrics: [
+          ["KorpoBingo", "Duration", { stat: "p50", period: 300 }],
+          ["KorpoBingo", "Duration", { stat: "p90", period: 300 }],
+          ["KorpoBingo", "Duration", { stat: "p99", period: 300 }],
+        ],
+        view: "timeSeries",
+        region: "us-east-1",
+        period: 300,
+      },
+    },
+    {
+      type: "metric",
+      x: 12,
+      y: 6,
+      width: 12,
+      height: 6,
+      properties: {
+        title: "Request Volume by Endpoint",
+        metrics: [
+          ["KorpoBingo", "RequestCount", "Method", "GET", "Path", "/rounds", { stat: "Sum" }],
+          ["KorpoBingo", "RequestCount", "Method", "POST", "Path", "/rounds", { stat: "Sum" }],
+          ["KorpoBingo", "RequestCount", "Method", "GET", "Path", "/boards", { stat: "Sum" }],
+          ["KorpoBingo", "RequestCount", "Method", "POST", "Path", "/boards", { stat: "Sum" }],
+          ["KorpoBingo", "RequestCount", "Method", "GET", "Path", "/players", { stat: "Sum" }],
+          ["KorpoBingo", "RequestCount", "Method", "POST", "Path", "/players", { stat: "Sum" }],
+          ["KorpoBingo", "RequestCount", "Method", "GET", "Path", "/words", { stat: "Sum" }],
+          ["KorpoBingo", "RequestCount", "Method", "POST", "Path", "/words", { stat: "Sum" }],
+        ],
+        view: "timeSeries",
+        region: "us-east-1",
+        period: 300,
+      },
+    },
+  ],
+};
+
+export const dashboard = new aws.cloudwatch.Dashboard("KorpoBingoDashboard", {
+  dashboardName: $interpolate`korpobingo-${$app.stage}`,
+  dashboardBody: JSON.stringify(dashboardBody),
+});

--- a/packages/functions/src/boards.ts
+++ b/packages/functions/src/boards.ts
@@ -28,6 +28,17 @@ export const handler = wrapHandler(async (event) => {
         }
         const board = await Board.markCell(roundId, playerName, cellIndex);
         const bingo = Board.checkBingo(board.marked, board.size);
+        if (bingo.hasBingo) {
+          console.log(
+            JSON.stringify({
+              level: "INFO",
+              event: "BINGO_ACHIEVED",
+              roundId,
+              playerName,
+              lines: bingo.lines.length,
+            }),
+          );
+        }
         return json(200, { ...board, hasBingo: bingo.hasBingo, bingoLines: bingo.lines });
       }
 

--- a/packages/functions/src/players.ts
+++ b/packages/functions/src/players.ts
@@ -28,6 +28,14 @@ export const handler = wrapHandler(async (event) => {
         playerName: body.playerName as string,
         pin: body.pin as string,
       });
+      console.log(
+        JSON.stringify({
+          level: "INFO",
+          event: "PLAYER_JOINED",
+          roundId: player.roundId,
+          playerName: player.playerName,
+        }),
+      );
       return json(201, player);
     }
     case "GET": {

--- a/packages/functions/src/rounds.ts
+++ b/packages/functions/src/rounds.ts
@@ -33,6 +33,16 @@ export const handler = wrapHandler(async (event) => {
 
         await Round.updateStatus(roundId, status);
 
+        if (status === "playing") {
+          console.log(
+            JSON.stringify({ level: "INFO", event: "GAME_STARTED", roundId, playerName }),
+          );
+        } else if (status === "finished") {
+          console.log(
+            JSON.stringify({ level: "INFO", event: "ROUND_FINISHED", roundId, playerName }),
+          );
+        }
+
         // When starting the game, create boards for all registered players
         if (status === "playing") {
           const players = await Player.listByRound(roundId);
@@ -60,6 +70,15 @@ export const handler = wrapHandler(async (event) => {
         boardSize: body.boardSize as 3 | 4 | undefined,
         durationDays: body.durationDays as number | undefined,
       });
+      console.log(
+        JSON.stringify({
+          level: "INFO",
+          event: "ROUND_CREATED",
+          roundId: round.roundId,
+          name: round.name,
+          boardSize: round.boardSize,
+        }),
+      );
       return json(201, round);
     }
     case "GET": {

--- a/packages/functions/src/words.ts
+++ b/packages/functions/src/words.ts
@@ -82,6 +82,16 @@ export const handler = wrapHandler(async (event) => {
         text: body.text as string,
         submittedBy,
       });
+      console.log(
+        JSON.stringify({
+          level: "INFO",
+          event: "WORDS_SUBMITTED",
+          roundId,
+          submittedBy,
+          wordId: word.wordId,
+          text: word.text,
+        }),
+      );
       return json(201, word);
     }
     case "GET": {

--- a/sst.config.ts
+++ b/sst.config.ts
@@ -21,6 +21,7 @@ export default $config({
     const storage = await import("./infra/storage");
     const api = await import("./infra/api");
     const { web } = await import("./infra/web");
+    await import("./infra/monitoring");
 
     return {
       RoundsTable: storage.roundsTable.name,


### PR DESCRIPTION
## Summary

- Enhanced `wrapHandler()` middleware with structured JSON logging for every request (method, path, roundId, statusCode, duration) and error details (type, message, stack — never PINs)
- Added CloudWatch Embedded Metric Format (EMF) to auto-extract `RequestCount`, `Duration`, and `ErrorCount` metrics per endpoint into the `KorpoBingo` namespace
- Added business event logs across all handlers: `ROUND_CREATED`, `GAME_STARTED`, `ROUND_FINISHED`, `BINGO_ACHIEVED`, `PLAYER_JOINED`, `WORDS_SUBMITTED`
- Configured 30-day log retention for all Lambda functions via SST transform
- Created a CloudWatch dashboard (`infra/monitoring.ts`) with panels for request volume, error rate, latency percentiles, and per-endpoint breakdowns

## Test plan

- [ ] Deploy to dev stage and verify structured JSON logs appear in CloudWatch for each endpoint
- [ ] Confirm EMF metrics show up under `KorpoBingo` namespace in CloudWatch Metrics
- [ ] Verify CloudWatch dashboard is created with correct panels
- [ ] Check that PIN values are never present in any log output
- [ ] Trigger a bingo and confirm `BINGO_ACHIEVED` event is logged

Closes #61