### PR TITLE
feat: upgrade Lambda runtime to nodejs22.x

### DIFF
--- a/infra/api.ts
+++ b/infra/api.ts
@@ -4,6 +4,7 @@ const tables = [roundsTable, wordsTable, playersTable, boardsTable];
 
 const functionTransform: sst.aws.ApiGatewayV2RouteArgs["transform"] = {
   function: {
+    runtime: "nodejs22.x",
     logging: {
       retention: "30 days",
     },


### PR DESCRIPTION
## Summary
- Explicitly sets Lambda handler runtime to `nodejs22.x` in the API Gateway function transform (`infra/api.ts`)
- Upgrades from the SST default of `nodejs20.x` to the latest supported Node.js LTS runtime
- Aligns Lambda runtime with the project's existing Node 22 configuration (`@tsconfig/node22`, `@types/node@^22`, CI uses Node 22)

Closes #75

## Test plan
- [ ] Deploy to dev stage (`AWS_PROFILE=korpobingo npx sst deploy`) and verify all 4 Lambda handlers use nodejs22.x runtime
- [ ] Test all API endpoints (rounds, words, players, boards) for correct behavior
- [ ] Verify CloudWatch logs show Node 22.x runtime in Lambda execution environment